### PR TITLE
Fix: Fix mixed precision

### DIFF
--- a/mmdetection/tools/train.py
+++ b/mmdetection/tools/train.py
@@ -29,7 +29,8 @@ def parse_args():
     
     parser.add_argument('--train-type', type=str, default=None, help='aug, model, data')
     parser.add_argument('--work-dir', default=None, help='the dir to save logs and models')
-
+    parser.add_argument('--fp16', type=bool, default=False)
+    
     parser.add_argument(
         '--resume-from', help='the checkpoint file to resume from')
     parser.add_argument(
@@ -118,6 +119,10 @@ def main():
     config_file = f"configs/_teamconfig_/[{args.train_type}]{config_name}/{config_name}_config.py"
     
     cfg = Config.fromfile(config_file)
+    
+    # Enable FP16 training if --fp16 argument is passed
+    if args.fp16:
+        cfg.setdefault('fp16', dict(loss_scale=512.))
     
     # replace the ${key} with the value of cfg.key
     cfg = replace_cfg_vals(cfg)


### PR DESCRIPTION
![fp16](https://github.com/boostcampaitech5/level2_objectdetection-cv-03/assets/120040458/bbe91c93-7fa4-4e14-920e-bf8804d1366e)

```--fp16```의 조건을 ```True```로 하시면 half precision을 사용해서 학습합니다

```--fp16```을 명시하지 않으면 default로 ```False```가 들어가서 기본 상태로 학습합니다!

example : ```python tools/train.py ColorTransform_v3 --train-type aug --fp16 True```

issue #9 